### PR TITLE
Actually set the $specified_profile_id when checking

### DIFF
--- a/src/Handler/GoogleAnalyticsHandler.php
+++ b/src/Handler/GoogleAnalyticsHandler.php
@@ -113,6 +113,9 @@ class GoogleAnalyticsHandler
 
             //Get all of the profiles associated with user
             $items = $profiles->getItems();
+            
+            //Get the specified profile ID
+            $specified_profile_id = $this->config->getGaProfileId();
 
             //Check to see if Bolt Extension configuration has profile id already
             if (! empty($specified_profile_id)) {


### PR DESCRIPTION
Otherwise it will never use the specified profile id.